### PR TITLE
Changed PBC handling in Distance and NumberOfContacts

### DIFF
--- a/cvlib/__init__.py
+++ b/cvlib/__init__.py
@@ -2,4 +2,10 @@
 
 # Add imports here
 from ._version import __version__  # noqa: F401
-from .cvlib import Angle, Distance, NumberOfContacts, RadiusOfGyration, Torsion  # noqa: F401
+from .cvlib import (  # noqa: F401
+    Angle,
+    Distance,
+    NumberOfContacts,
+    RadiusOfGyration,
+    Torsion,
+)

--- a/cvlib/__init__.py
+++ b/cvlib/__init__.py
@@ -2,8 +2,4 @@
 
 # Add imports here
 from ._version import __version__  # noqa: F401
-from .cvlib import Angle  # noqa: F401
-from .cvlib import Distance  # noqa: F401
-from .cvlib import NumberOfContacts  # noqa: F401
-from .cvlib import RadiusOfGyration  # noqa: F401
-from .cvlib import Torsion  # noqa: F401
+from .cvlib import Angle, Distance, NumberOfContacts, RadiusOfGyration, Torsion  # noqa: F401

--- a/cvlib/cvlib.py
+++ b/cvlib/cvlib.py
@@ -94,9 +94,9 @@ class AbstractCollectiveVariable(openmm.Force):
             >>> import cvlib
             >>> args, defaults = cvlib.Distance.getArguments()
             >>> print(*args.items())
-            ('atom1', <class 'int'>) ('atom2', <class 'int'>)
+            ('atom1', <class 'int'>) ('atom2', <class 'int'>) ('pbc', <class 'bool'>)
             >>> print(*defaults.items())
-            <BLANKLINE>
+            ('pbc', True)
 
         Example
         =======
@@ -197,6 +197,8 @@ class Distance(openmm.CustomBondForce, AbstractCollectiveVariable):
             The index of the first atom
         atom2
             The index of the second atom
+        pbc
+            Whether to use periodic boundary conditions
 
     Example:
         >>> import cvlib
@@ -216,9 +218,10 @@ class Distance(openmm.CustomBondForce, AbstractCollectiveVariable):
 
     """
 
-    def __init__(self, atom1: int, atom2: int) -> None:
+    def __init__(self, atom1: int, atom2: int, pbc: bool=True) -> None:
         super().__init__("r")
         self.addBond(atom1, atom2, [])
+        self.setUsesPeriodicBoundaryConditions(pbc)
         self._registerCV(mmunit.nanometers, atom1, atom2)
 
 
@@ -402,11 +405,11 @@ class NumberOfContacts(openmm.CustomNonbondedForce, AbstractCollectiveVariable):
             The indices of the atoms in the second group
         numAtoms
             The total number of atoms in the system (required by OpenMM)
+        pbc
+            Whether the system has periodic boundary conditions
         stepFunction
             The function "step(1-x)" (for analysis only) or a continuous approximation
             thereof
-        pbc
-            Whether the system has periodic boundary conditions
         thresholdDistance
             The threshold distance for considering two atoms as being in contact
         cutoffDistance
@@ -423,7 +426,7 @@ class NumberOfContacts(openmm.CustomNonbondedForce, AbstractCollectiveVariable):
         >>> model = testsystems.AlanineDipeptideVacuum()
         >>> carbons = [a.index for a in model.topology.atoms() if a.element == app.element.carbon]
         >>> num_atoms = model.topology.getNumAtoms()
-        >>> optionals = {"stepFunction": "step(1-x)", "pbc": False}
+        >>> optionals = {"pbc": False, "stepFunction": "step(1-x)"}
         >>> nc = cvlib.NumberOfContacts(carbons, carbons, num_atoms, **optionals)
         >>> model.system.addForce(nc)
         5
@@ -440,8 +443,8 @@ class NumberOfContacts(openmm.CustomNonbondedForce, AbstractCollectiveVariable):
         group1: List[int],
         group2: List[int],
         numAtoms: int,
-        stepFunction: str = "1/(1+x^6)",
         pbc: bool = True,
+        stepFunction: str = "1/(1+x^6)",
         thresholdDistance: QuantityOrFloat = 0.3,
         cutoffDistance: QuantityOrFloat = 0.6,
         switchingDistance: QuantityOrFloat = 0.5,
@@ -461,8 +464,8 @@ class NumberOfContacts(openmm.CustomNonbondedForce, AbstractCollectiveVariable):
             group1,
             group2,
             numAtoms,
-            stepFunction,
             pbc,
+            stepFunction,
             _in_md_units(thresholdDistance),
             _in_md_units(cutoffDistance),
             _in_md_units(switchingDistance),

--- a/cvlib/cvlib.py
+++ b/cvlib/cvlib.py
@@ -218,7 +218,7 @@ class Distance(openmm.CustomBondForce, AbstractCollectiveVariable):
 
     """
 
-    def __init__(self, atom1: int, atom2: int, pbc: bool=True) -> None:
+    def __init__(self, atom1: int, atom2: int, pbc: bool = True) -> None:
         super().__init__("r")
         self.addBond(atom1, atom2, [])
         self.setUsesPeriodicBoundaryConditions(pbc)

--- a/cvlib/tests/test_cvlib.py
+++ b/cvlib/tests/test_cvlib.py
@@ -193,7 +193,7 @@ def test_number_of_contacts():
     contacts = [np.linalg.norm(pos[i] - pos[j]) <= threshold for i, j in pairs]
     num_atoms = model.topology.getNumAtoms()
     number_of_contacts = cvlib.NumberOfContacts(
-        group1, group2, num_atoms, stepFunction="step(1-x)", thresholdDistance=threshold
+        group1, group2, num_atoms, pbc=False, stepFunction="step(1-x)", thresholdDistance=threshold
     )
     model.system.addForce(number_of_contacts)
     integrator = openmm.CustomIntegrator(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,6 @@ default-tag = "0.0.0"
 
 [tool.versioningit.write]
 file = "cvlib/_version.py"
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
## Description
Changed how periodic boundary conditions are handled in two CVs:
- __Distance__: included `pbc` as an argument with default value `True`
- __NumberOfContacts__: changed position of `pbc` in argument list, making it the first optional one