### PR TITLE
Implemented angle and hydrogen-bond helix content CVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ as:
 * [Angle](https://cvlib-for-openmm.readthedocs.io/en/latest/api/Angle.html)
 * [Distance](https://cvlib-for-openmm.readthedocs.io/en/latest/api/Distance.html)
 * [Helix angle content](https://cvlib-for-openmm.readthedocs.io/en/latest/api/HelixAngleContent.html)
+* [Helix H-bond content](https://cvlib-for-openmm.readthedocs.io/en/latest/api/HelixHBondContent.html)
 * [Helix torsion content](https://cvlib-for-openmm.readthedocs.io/en/latest/api/HelixTorsionContent.html)
 * [Number of contacts](https://cvlib-for-openmm.readthedocs.io/en/latest/api/NumberOfContacts.html)
 * [Radius of gyration](https://cvlib-for-openmm.readthedocs.io/en/latest/api/RadiusOfGyration.html)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ as:
 
 * [Angle](https://cvlib-for-openmm.readthedocs.io/en/latest/api/Angle.html)
 * [Distance](https://cvlib-for-openmm.readthedocs.io/en/latest/api/Distance.html)
+* [Helix angle content](https://cvlib-for-openmm.readthedocs.io/en/latest/api/HelixAngleContent.html)
 * [Helix torsion content](https://cvlib-for-openmm.readthedocs.io/en/latest/api/HelixTorsionContent.html)
 * [Number of contacts](https://cvlib-for-openmm.readthedocs.io/en/latest/api/NumberOfContacts.html)
 * [Radius of gyration](https://cvlib-for-openmm.readthedocs.io/en/latest/api/RadiusOfGyration.html)

--- a/cvlib/__init__.py
+++ b/cvlib/__init__.py
@@ -5,6 +5,7 @@ from ._version import __version__  # noqa: F401
 from .angle import Angle  # noqa: F401
 from .distance import Distance  # noqa: F401
 from .helix_angle_content import HelixAngleContent  # noqa: F401
+from .helix_hbond_content import HelixHBondContent  # noqa: F401
 from .helix_torsion_content import HelixTorsionContent  # noqa: F401
 from .number_of_contacts import NumberOfContacts  # noqa: F401
 from .radius_of_gyration import RadiusOfGyration  # noqa: F401

--- a/cvlib/__init__.py
+++ b/cvlib/__init__.py
@@ -4,6 +4,7 @@
 from ._version import __version__  # noqa: F401
 from .angle import Angle  # noqa: F401
 from .distance import Distance  # noqa: F401
+from .helix_angle_content import HelixAngleContent  # noqa: F401
 from .helix_torsion_content import HelixTorsionContent  # noqa: F401
 from .number_of_contacts import NumberOfContacts  # noqa: F401
 from .radius_of_gyration import RadiusOfGyration  # noqa: F401

--- a/cvlib/cvlib.py
+++ b/cvlib/cvlib.py
@@ -106,7 +106,7 @@ class AbstractCollectiveVariable(openmm.Force):
         """
         forces = context.getSystem().getForces()
         if not any(force.this == self.this for force in forces):
-            raise ValueError("This force is not part of the system in the given context.")
+            raise RuntimeError("This force is not part of the system in the given context.")
         free_groups = set(range(32)) - set(f.getForceGroup() for f in forces)
         old_group = self.getForceGroup()
         new_group = next(iter(free_groups))

--- a/cvlib/helix_angle_content.py
+++ b/cvlib/helix_angle_content.py
@@ -22,18 +22,18 @@ class HelixAngleContent(openmm.CustomAngleForce, AbstractCollectiveVariable):
 
     .. math::
 
-        \\alpha_{\\theta}({\\bf r}) = \\frac{1}{n-2} \\sum_{i=2}^{n-1} B\\left(
+        \\alpha_{\\theta}({\\bf r}) = \\frac{1}{n-2} \\sum_{i=2}^{n-1} B_m\\left(
             \\frac{\\theta^\\alpha_i({\\bf r}) - \\theta_{\\rm ref}}{\\theta_{\\rm tol}}
         \\right)
 
     where :math:`\\theta^\\alpha_i` is the angle formed by the alpha-carbon atoms of residues
     :math:`i-1`, :math:`i`, and :math:`i+1`, :math:`\\theta_{\\rm ref}` is its reference value in
     an alpha helix, and :math:`\\theta_{\\rm tol}` is the threshold tolerance around this
-    reference. The function :math:`B(x)` is a smooth `boxcar function
+    reference. The function :math:`B_m(x)` is a smooth `boxcar function
     <https://en.wikipedia.org/wiki/Boxcar_function>`_
 
     .. math::
-        B(x) = \\frac{1}{1 + x^{2m}}
+        B_m(x) = \\frac{1}{1 + x^{2m}}
 
     where :math:`m` is an integer parameter that controls its steepness.
 
@@ -76,13 +76,13 @@ class HelixAngleContent(openmm.CustomAngleForce, AbstractCollectiveVariable):
 
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         residues: Iterable[mmapp.topology.Residue],
         thetaReference: QuantityOrFloat = 88 * mmunit.degrees,
         tolerance: QuantityOrFloat = 15 * mmunit.degrees,
         halfExponent: int = 3,
-    ):
+    ) -> None:
         def find_alpha_carbon(residue: mmapp.topology.Residue) -> int:
             for atom in residue.atoms():
                 if atom.name == "CA":

--- a/cvlib/helix_angle_content.py
+++ b/cvlib/helix_angle_content.py
@@ -1,0 +1,102 @@
+"""
+.. class:: HelixAngleContent
+   :platform: Linux, MacOS, Windows
+   :synopsis: Fractional alpha-helix angle content of a sequence of residues
+
+.. classauthor:: Charlles Abreu <craabreu@gmail.com>
+
+"""
+
+from typing import Iterable
+
+import openmm
+from openmm import app as mmapp
+from openmm import unit as mmunit
+
+from .cvlib import AbstractCollectiveVariable, QuantityOrFloat, in_md_units
+
+
+class HelixAngleContent(openmm.CustomAngleForce, AbstractCollectiveVariable):
+    """
+    Fractional :math:`\\alpha`-helix angle content of a sequence of `n` residues:
+
+    .. math::
+
+        \\alpha_{\\theta}({\\bf r}) = \\frac{1}{2(n-2)} \\sum_{i=2}^{n-1} B\\left(
+            \\frac{\\theta^{{\\rm C}_\\alpha}_i({\\bf r}) - \\theta_{\\rm ref}}{\\theta_{\\rm tol}}
+        \\right)
+
+    where :math:`\\theta^{{\\rm C}_\\alpha}_i` is the angle formed by the alpha-carbon atoms of
+    residues :math:`i-1`, :math:`i`, and :math:`i+1`, :math:`\\theta_{\\rm ref}` is its reference
+    value in an alpha helix, and :math:`\\theta_{\\rm tol}` is the threshold tolerance around this
+    reference. The function :math:`B(x)` is a smooth `boxcar function
+    <https://en.wikipedia.org/wiki/Boxcar_function>`_:
+
+    .. math::
+        B(x) = \\frac{1}{1 + x^{2m}}
+
+    where :math:`m` is an integer parameter that controls its steepness.
+
+    Parameters
+    ----------
+        residues
+            The residues in the sequence
+        thetaReference
+            The reference value of the :math:`{\\rm C}_\\alpha{\\rm -C}_\\alpha{\\rm -C}_\\alpha`
+            angle in an alpha helix
+        tolerance
+            The threshold tolerance around the reference values
+        halfExponent
+            The parameter :math:`m` of the boxcar function
+
+    Raises
+    ------
+        ValueError
+            If some residue does not contain a :math:`{\\rm C}_\\alpha` atom
+
+    Example
+    -------
+        >>> import cvlib
+        >>> import openmm as mm
+        >>> from openmm import app, unit
+        >>> from openmmtools import testsystems
+        >>> model = testsystems.LysozymeImplicit()
+        >>> residues = [r for r in model.topology.residues() if 59 <= r.index <= 79]
+        >>> print(*[r.name for r in residues])
+        LYS ASP GLU ALA GLU LYS LEU PHE ASN GLN ASP VAL ASP ALA ALA VAL ARG GLY ILE LEU ARG
+        >>> helix_content = cvlib.HelixAngleContent(residues)
+        >>> model.system.addForce(helix_content)
+        6
+        >>> platform = openmm.Platform.getPlatformByName('Reference')
+        >>> integrator = openmm.VerletIntegrator(0)
+        >>> context = openmm.Context(model.system, integrator, platform)
+        >>> context.setPositions(model.positions)
+        >>> print(helix_content.evaluateInContext(context, 6))
+        0.987399 dimensionless
+
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        residues: Iterable[mmapp.topology.Residue],
+        thetaReference: QuantityOrFloat = 88 * mmunit.degrees,
+        tolerance: QuantityOrFloat = 15 * mmunit.degrees,
+        halfExponent: int = 3,
+    ):
+        def find_alpha_carbon(residue: mmapp.topology.Residue) -> int:
+            for atom in residue.atoms():
+                if atom.name == "CA":
+                    return atom.index
+            raise ValueError(f"Could not find atom CA in residue {residue.name}{residue.id}")
+
+        theta_ref, tol = map(in_md_units, [thetaReference, tolerance])
+        num_angles = len(residues) - 2
+        super().__init__(f"{1/num_angles}/(1+x^{2*halfExponent}); x=(theta-{theta_ref})/{tol}")
+        for i in range(1, len(residues) - 1):
+            self.addAngle(
+                find_alpha_carbon(residues[i - 1]),
+                find_alpha_carbon(residues[i]),
+                find_alpha_carbon(residues[i + 1]),
+                [],
+            )
+        self._registerCV(mmunit.dimensionless, residues, theta_ref, tol, halfExponent)

--- a/cvlib/helix_angle_content.py
+++ b/cvlib/helix_angle_content.py
@@ -22,15 +22,15 @@ class HelixAngleContent(openmm.CustomAngleForce, AbstractCollectiveVariable):
 
     .. math::
 
-        \\alpha_{\\theta}({\\bf r}) = \\frac{1}{2(n-2)} \\sum_{i=2}^{n-1} B\\left(
-            \\frac{\\theta^{{\\rm C}_\\alpha}_i({\\bf r}) - \\theta_{\\rm ref}}{\\theta_{\\rm tol}}
+        \\alpha_{\\theta}({\\bf r}) = \\frac{1}{n-2} \\sum_{i=2}^{n-1} B\\left(
+            \\frac{\\theta^\\alpha_i({\\bf r}) - \\theta_{\\rm ref}}{\\theta_{\\rm tol}}
         \\right)
 
-    where :math:`\\theta^{{\\rm C}_\\alpha}_i` is the angle formed by the alpha-carbon atoms of
-    residues :math:`i-1`, :math:`i`, and :math:`i+1`, :math:`\\theta_{\\rm ref}` is its reference
-    value in an alpha helix, and :math:`\\theta_{\\rm tol}` is the threshold tolerance around this
+    where :math:`\\theta^\\alpha_i` is the angle formed by the alpha-carbon atoms of residues
+    :math:`i-1`, :math:`i`, and :math:`i+1`, :math:`\\theta_{\\rm ref}` is its reference value in
+    an alpha helix, and :math:`\\theta_{\\rm tol}` is the threshold tolerance around this
     reference. The function :math:`B(x)` is a smooth `boxcar function
-    <https://en.wikipedia.org/wiki/Boxcar_function>`_:
+    <https://en.wikipedia.org/wiki/Boxcar_function>`_
 
     .. math::
         B(x) = \\frac{1}{1 + x^{2m}}

--- a/cvlib/helix_angle_content.py
+++ b/cvlib/helix_angle_content.py
@@ -35,7 +35,12 @@ class HelixAngleContent(openmm.CustomAngleForce, AbstractCollectiveVariable):
     .. math::
         B_m(x) = \\frac{1}{1 + x^{2m}}
 
-    where :math:`m` is an integer parameter that controls its steepness.
+    where :math:`m` is an integer parameter that controls its steepness. Note that :math:`x` is
+    always elevated to an even power.
+
+    .. note::
+
+        The residues must be from a single chain and be ordered in sequence.
 
     Parameters
     ----------

--- a/cvlib/helix_hbond_content.py
+++ b/cvlib/helix_hbond_content.py
@@ -75,7 +75,11 @@ class HelixHBondContent(openmm.CustomBondForce, AbstractCollectiveVariable):
             for atom in residue.atoms():
                 if regex.match(pattern, atom.name):
                     return atom.index
-            raise ValueError(f"Could not find atom {pattern} in residue {residue.name}{residue.id}")
+            raise ValueError(
+                f"Could not find atom matching regex "
+                f"'{pattern.pattern}'"
+                f" in residue {residue.name}{residue.id}"
+            )
 
         threshold = in_md_units(thresholdDistance)
         super().__init__(f"({stepFunction})/{len(residues) - 4}; x=r/{threshold}")

--- a/cvlib/helix_hbond_content.py
+++ b/cvlib/helix_hbond_content.py
@@ -8,7 +8,7 @@
 """
 
 import re as regex
-from typing import Iterable
+from typing import Iterable, Pattern
 
 import openmm
 from openmm import app as mmapp
@@ -77,7 +77,7 @@ class HelixHBondContent(openmm.CustomBondForce, AbstractCollectiveVariable):
         thresholdDistance: QuantityOrFloat = 0.33 * mmunit.nanometers,
         stepFunction: str = "1/(1+x^6)",
     ) -> None:
-        def find_atom(residue: mmapp.topology.Residue, pattern: regex.Pattern) -> int:
+        def find_atom(residue: mmapp.topology.Residue, pattern: Pattern) -> int:
             for atom in residue.atoms():
                 if regex.match(pattern, atom.name):
                     return atom.index

--- a/cvlib/helix_hbond_content.py
+++ b/cvlib/helix_hbond_content.py
@@ -30,8 +30,14 @@ class HelixHBondContent(openmm.CustomBondForce, AbstractCollectiveVariable):
     where :math:`{\\bf r}^{\\rm H}_k` and :math:`{\\bf r}^{\\rm O}_k` are the positions of the
     hydrogen and oxygen atoms, respectively bonded to the backbone nitrogen and carbon atoms of
     residue :math:`k`, :math:`d_{\\rm HB}` is the threshold distance for a hydrogen bond, and
-    :math:`S(x)` is a continuous approximation of :math:`H(1-x)`, where :math:`H(x)` is the
-    `Heaviside step function <https://en.wikipedia.org/wiki/Heaviside_step_function>`_.
+    :math:`S(x)` is a step function equal to 1 if a contact is made or equal to 0 otherwise. In
+    analysis, it is fine to make :math:`S(x) = H(1-x)`, where `H` is the `Heaviside step function
+    <https://en.wikipedia.org/wiki/Heaviside_step_function>`_. In a simulation, however,
+    :math:`S(x)` should continuously approximate :math:`H(1-x)` for :math:`x \\geq 0`.
+
+    .. note::
+
+        The residues must be from a single chain and be ordered in sequence.
 
     Parameters
     ----------

--- a/cvlib/helix_hbond_content.py
+++ b/cvlib/helix_hbond_content.py
@@ -1,0 +1,90 @@
+"""
+.. class:: HelixHBondContent
+   :platform: Linux, MacOS, Windows
+   :synopsis: Fractional alpha-helix hydrogen-bond content of a sequence of residues
+
+.. classauthor:: Charlles Abreu <craabreu@gmail.com>
+
+"""
+
+import re as regex
+from typing import Iterable
+
+import openmm
+from openmm import app as mmapp
+from openmm import unit as mmunit
+
+from .cvlib import AbstractCollectiveVariable, QuantityOrFloat, in_md_units
+
+
+class HelixHBondContent(openmm.CustomBondForce, AbstractCollectiveVariable):
+    """
+    Fractional :math:`\\alpha`-helix hydrogen-bond content of a sequence of `n` residues:
+
+    .. math::
+
+        \\alpha_{\\rm HB}({\\bf r}) = \\frac{1}{n-4} \\sum_{i=5}^n S\\left(
+            \\frac{\\| {\\bf r}^{\\rm H}_i - {\\bf r}^{\\rm O}_{i-4} \\|}{d_{\\rm HB}}
+        \\right)
+
+    where :math:`{\\bf r}^{\\rm H}_k` and :math:`{\\bf r}^{\\rm O}_k` are the positions of the
+    hydrogen and oxygen atoms, respectively bonded to the backbone nitrogen and carbon atoms of
+    residue :math:`k`, :math:`d_{\\rm HB}` is the threshold distance for a hydrogen bond, and
+    :math:`S(x)` is a continuous approximation of :math:`H(1-x)`, where :math:`H(x)` is the
+    `Heaviside step function <https://en.wikipedia.org/wiki/Heaviside_step_function>`_.
+
+    Parameters
+    ----------
+        residues
+            The residues in the sequence
+        thresholdDistance
+            The threshold distance for a hydrogen bond
+        stepFunction
+            A continuous approximation of :math:`H(1-x)`, where :math:`H(x)` is the Heaviside step
+            function.
+
+    Example
+    -------
+        >>> import cvlib
+        >>> import openmm as mm
+        >>> from openmm import app, unit
+        >>> from openmmtools import testsystems
+        >>> model = testsystems.LysozymeImplicit()
+        >>> residues = [r for r in model.topology.residues() if 59 <= r.index <= 79]
+        >>> print(*[r.name for r in residues])
+        LYS ASP GLU ALA GLU LYS LEU PHE ASN GLN ASP VAL ASP ALA ALA VAL ARG GLY ILE LEU ARG
+        >>> helix_content = cvlib.HelixHBondContent(residues)
+        >>> model.system.addForce(helix_content)
+        6
+        >>> platform = openmm.Platform.getPlatformByName('Reference')
+        >>> integrator = openmm.VerletIntegrator(0)
+        >>> context = openmm.Context(model.system, integrator, platform)
+        >>> context.setPositions(model.positions)
+        >>> print(helix_content.evaluateInContext(context, 6))
+        0.93414 dimensionless
+
+    """
+
+    def __init__(
+        self,
+        residues: Iterable[mmapp.topology.Residue],
+        thresholdDistance: QuantityOrFloat = 0.33 * mmunit.nanometers,
+        stepFunction: str = "1/(1+x^6)",
+    ) -> None:
+        def find_atom(residue: mmapp.topology.Residue, pattern: regex.Pattern) -> int:
+            for atom in residue.atoms():
+                if regex.match(pattern, atom.name):
+                    return atom.index
+            raise ValueError(f"Could not find atom {pattern} in residue {residue.name}{residue.id}")
+
+        threshold = in_md_units(thresholdDistance)
+        super().__init__(f"({stepFunction})/{len(residues) - 4}; x=r/{threshold}")
+        hydrogen_pattern = regex.compile("\\b(H|1H|HN1|HT1|H1|HN)\\b")
+        oxygen_pattern = regex.compile("\\b(O|OCT1|OC1|OT1|O1)\\b")
+        for i in range(4, len(residues)):
+            self.addBond(
+                find_atom(residues[i - 4], oxygen_pattern),
+                find_atom(residues[i], hydrogen_pattern),
+                [],
+            )
+        self._registerCV(mmunit.dimensionless, residues, threshold, stepFunction)

--- a/cvlib/helix_torsion_content.py
+++ b/cvlib/helix_torsion_content.py
@@ -35,7 +35,7 @@ class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable)
     angles of residue :math:`i`, :math:`\\phi_{\\rm ref}` and :math:`\\psi_{\\rm ref}` are their
     reference values in an alpha helix :cite:`Hovmoller_2002`, and :math:`\\theta_{\\rm tol}` is
     the threshold tolerance around these refenrences. The function :math:`B(x)` is a smooth `boxcar
-    function <https://en.wikipedia.org/wiki/Boxcar_function>`_:
+    function <https://en.wikipedia.org/wiki/Boxcar_function>`_
 
     .. math::
         B(x) = \\frac{1}{1 + x^{2m}}

--- a/cvlib/helix_torsion_content.py
+++ b/cvlib/helix_torsion_content.py
@@ -18,7 +18,7 @@ from .cvlib import AbstractCollectiveVariable, QuantityOrFloat, in_md_units
 
 class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable):
     """
-     Fractional :math:`\\alpha`-helix Ramachandran content of a sequence of `n` residues:
+    Fractional :math:`\\alpha`-helix Ramachandran content of a sequence of `n` residues:
 
     .. math::
 

--- a/cvlib/helix_torsion_content.py
+++ b/cvlib/helix_torsion_content.py
@@ -23,10 +23,10 @@ class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable)
     .. math::
 
         \\alpha_{\\phi,\\psi}({\\bf r}) = \\frac{1}{2(n-2)} \\sum_{i=2}^{n-1} \\left[
-            B\\left(
+            B_m\\left(
                 \\frac{\\phi_i({\\bf r}) - \\phi_{\\rm ref}}{\\theta_{\\rm tol}}
             \\right) +
-            B\\left(
+            B_m\\left(
                 \\frac{\\psi_i({\\bf r}) - \\psi_{\\rm ref}}{\\theta_{\\rm tol}}
             \\right)
         \\right]
@@ -34,11 +34,11 @@ class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable)
     where :math:`\\phi_i({\\bf r})` and :math:`\\psi_i({\\bf r})` are the Ramachandran dihedral
     angles of residue :math:`i`, :math:`\\phi_{\\rm ref}` and :math:`\\psi_{\\rm ref}` are their
     reference values in an alpha helix :cite:`Hovmoller_2002`, and :math:`\\theta_{\\rm tol}` is
-    the threshold tolerance around these refenrences. The function :math:`B(x)` is a smooth `boxcar
-    function <https://en.wikipedia.org/wiki/Boxcar_function>`_
+    the threshold tolerance around these refenrences. The function :math:`B_m(x)` is a smooth
+    `boxcar function <https://en.wikipedia.org/wiki/Boxcar_function>`_
 
     .. math::
-        B(x) = \\frac{1}{1 + x^{2m}}
+        B_m(x) = \\frac{1}{1 + x^{2m}}
 
     where :math:`m` is an integer parameter that controls its steepness.
 
@@ -95,7 +95,7 @@ class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable)
         psiReference: QuantityOrFloat = -41.1 * mmunit.degrees,
         tolerance: QuantityOrFloat = 25 * mmunit.degrees,
         halfExponent: int = 3,
-    ):
+    ) -> None:
         def find_atom(residue: mmapp.topology.Residue, name: str) -> int:
             for atom in residue.atoms():
                 if atom.name == name:

--- a/cvlib/helix_torsion_content.py
+++ b/cvlib/helix_torsion_content.py
@@ -61,10 +61,10 @@ class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable)
         halfExponent
             The parameter :math:`m` of the boxcar function
 
-        Raises
-        ------
-            ValueError
-                If any residue
+    Raises
+    ------
+        ValueError
+            If some residue does not contain a :math:`\\phi` or :math:`\\psi` angle
 
     Example
     -------

--- a/cvlib/helix_torsion_content.py
+++ b/cvlib/helix_torsion_content.py
@@ -40,7 +40,8 @@ class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable)
     .. math::
         B_m(x) = \\frac{1}{1 + x^{2m}}
 
-    where :math:`m` is an integer parameter that controls its steepness.
+    where :math:`m` is an integer parameter that controls its steepness. Note that :math:`x` is
+    always elevated to an even power.
 
     .. note::
 

--- a/cvlib/tests/test_cvlib.py
+++ b/cvlib/tests/test_cvlib.py
@@ -312,6 +312,35 @@ def test_helix_torsion_content():
     assert cv_value / cv_value.unit == pytest.approx(computed_value)
 
 
+def test_helix_angle_content():
+    """
+    Test whether a helix ramachandran content is computed correctly.
+
+    """
+    model = testsystems.LysozymeImplicit()
+
+    positions = model.positions.value_in_unit(unit.nanometers)
+    traj = mdtraj.Trajectory(positions, mdtraj.Topology.from_openmm(model.topology))
+    alpha_carbons = traj.top.select("name CA")
+    angle_atoms = np.array([alpha_carbons[:-2], alpha_carbons[1:-1], alpha_carbons[2:]]).T
+    angles = mdtraj.compute_angles(traj, angle_atoms)
+    x = (np.rad2deg(angles.ravel()) - 88) / 15
+    computed_value = np.sum(1 / (1 + x**6)) / len(x)
+
+    residues = list(model.topology.residues())
+    with pytest.raises(ValueError) as excinfo:
+        helix_content = cvlib.HelixAngleContent(residues)
+    assert str(excinfo.value) == "Could not find atom CA in residue TMP163"
+    helix_content = cvlib.HelixAngleContent(residues[0:-1])
+    model.system.addForce(helix_content)
+    integrator = openmm.VerletIntegrator(0)
+    platform = openmm.Platform.getPlatformByName("Reference")
+    context = openmm.Context(model.system, integrator, platform)
+    context.setPositions(model.positions)
+    cv_value = helix_content.evaluateInContext(context)
+    assert cv_value / cv_value.unit == pytest.approx(computed_value)
+
+
 def test_helix_torsion_similarity():
     """
     Test whether a torsion similarity CV is computed correctly.

--- a/cvlib/tests/test_cvlib.py
+++ b/cvlib/tests/test_cvlib.py
@@ -96,6 +96,22 @@ def perform_common_tests(
     assert mass1 / mass1.unit == mass2 / mass2.unit
 
 
+def test_cv_is_in_context():
+    """
+    Test whether a collective variable is in a context.
+
+    """
+    model = testsystems.AlanineDipeptideVacuum()
+    rg_cv = cvlib.RadiusOfGyration(range(model.system.getNumParticles()))
+    integrator = openmm.CustomIntegrator(0)
+    platform = openmm.Platform.getPlatformByName("Reference")
+    context = openmm.Context(model.system, integrator, platform)
+    context.setPositions(model.positions)
+    with pytest.raises(RuntimeError) as excinfo:
+        rg_cv.evaluateInContext(context)
+    assert str(excinfo.value) == "This force is not part of the system in the given context."
+
+
 def test_distance():
     """
     Test whether a distance is computed correctly.


### PR DESCRIPTION
## Description
Implemented two new collective variables for measuring the fractional alpha-helix content of a sequence of residues:
* __HelixAngleContent__:  approximate the fraction of angles among three consecutive alpha-carbon atoms that lie in a specified range (default: from 88-15 to 88+15 degrees)
* __HelixHBondContent__:  approximate the fraction of contacts between the hydrogen atom bonded to the backbone "N" of a residue and the oxygen atom bonded to the backbone "C" of another residue four positions earlier in the sequence.