### PR TITLE
Implemented generic atomic and centroid CVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ objects. This CV Library provides several CVs of common use in molecular dynamic
 as:
 
 * [Angle](https://cvlib-for-openmm.readthedocs.io/en/latest/api/Angle.html)
+* [Atomic Function](https://cvlib-for-openmm.readthedocs.io/en/latest/api/AtomicFunction.html)
+* [Centroid Function](https://cvlib-for-openmm.readthedocs.io/en/latest/api/CentroidFunction.html)
 * [Distance](https://cvlib-for-openmm.readthedocs.io/en/latest/api/Distance.html)
 * [Helix angle content](https://cvlib-for-openmm.readthedocs.io/en/latest/api/HelixAngleContent.html)
 * [Helix H-bond content](https://cvlib-for-openmm.readthedocs.io/en/latest/api/HelixHBondContent.html)

--- a/cvlib/__init__.py
+++ b/cvlib/__init__.py
@@ -3,6 +3,8 @@
 # Add imports here
 from ._version import __version__  # noqa: F401
 from .angle import Angle  # noqa: F401
+from .atomic_function import AtomicFunction  # noqa: F401
+from .centroid_function import CentroidFunction  # noqa: F401
 from .distance import Distance  # noqa: F401
 from .helix_angle_content import HelixAngleContent  # noqa: F401
 from .helix_hbond_content import HelixHBondContent  # noqa: F401

--- a/cvlib/atomic_function.py
+++ b/cvlib/atomic_function.py
@@ -10,9 +10,8 @@
 from typing import Iterable
 
 import openmm
-from openmm import unit as mmunit
 
-from .cvlib import AbstractCollectiveVariable, UnitOrStr, str_to_unit, in_md_units
+from .cvlib import AbstractCollectiveVariable, UnitOrStr, in_md_units, str_to_unit
 
 
 class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable):
@@ -30,20 +29,21 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
     ----------
         function
             The function to be evaluated. It must be a valid :OpenMM:`CustomCompoundBondForce`
-            expression.
+            expression
         group
-            The group of atoms to be used in the function.
+            The group of atoms to be used in the function
         unit
             The unit of measurement of the collective variable. It must be compatible with the
             MD unit system (mass in `daltons`, distance in `nanometers`, time in `picoseconds`,
-            temperature in `kelvin`, energy in `kilojoules_per_mol`, angle in `radians`).
+            temperature in `kelvin`, energy in `kilojoules_per_mol`, angle in `radians`). If the
+            collective variables does not have a unit, use `dimensionless`
         pbc
-            Whether to use periodic boundary conditions.
+            Whether to use periodic boundary conditions
 
     Raises
     ------
         ValueError
-            If the collective variable is not compatible with the MD unit system.
+            If the collective variable is not compatible with the MD unit system
 
     Example
     -------
@@ -69,7 +69,7 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
         self,
         function: str,
         group: Iterable[int],
-        unit: UnitOrStr = mmunit.dimensionless,
+        unit: UnitOrStr,
         pbc: bool = True,
     ) -> None:
         super().__init__(len(group), function)
@@ -78,4 +78,4 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
         cv_unit = str_to_unit(unit) if isinstance(unit, str) else unit
         if in_md_units(1 * cv_unit) != 1:
             raise ValueError(f"Unit {cv_unit} is not compatible with the MD unit system.")
-        self._registerCV(cv_unit, str(unit), function, group, pbc)
+        self._registerCV(cv_unit, function, group, str(unit), pbc)

--- a/cvlib/atomic_function.py
+++ b/cvlib/atomic_function.py
@@ -1,0 +1,81 @@
+"""
+.. class:: AtomicFunction
+   :platform: Linux, MacOS, Windows
+   :synopsis: A generic function of the coordinates of a group of atoms
+
+.. classauthor:: Charlles Abreu <craabreu@gmail.com>
+
+"""
+
+from typing import Iterable
+
+import openmm
+from openmm import unit as mmunit
+
+from .cvlib import AbstractCollectiveVariable, UnitOrStr, str_to_unit, in_md_units
+
+
+class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable):
+    """
+    A generic function of the coordinates of a group of `n` atoms:
+
+    .. math::
+
+        f({\\bf r}) = F({\\bf r}_1, {\\bf r}_2, \\dots, {\\bf r}_n)
+
+    where :math:`F` is a user-defined function. The function :math:`F` is defined as a string and
+    can be any valid :OpenMM:`CustomCompoundBondForce` expression.
+
+    Parameters
+    ----------
+        function
+            The function to be evaluated. It must be a valid :OpenMM:`CustomCompoundBondForce`
+            expression.
+        group
+            The group of atoms to be used in the function.
+        unit
+            The unit of measurement of the collective variable. It must be compatible with the
+            MD unit system (mass in `daltons`, distance in `nanometers`, time in `picoseconds`,
+            temperature in `kelvin`, energy in `kilojoules_per_mol`, angle in `radians`).
+        pbc
+            Whether to use periodic boundary conditions.
+
+    Raises
+    ------
+        ValueError
+            If the collective variable is not compatible with the MD unit system.
+
+    Example
+    -------
+        >>> import cvlib
+        >>> import openmm as mm
+        >>> from openmmtools import testsystems
+        >>> model = testsystems.AlanineDipeptideVacuum()
+        >>> angle = cvlib.Angle(0, 11, 21)
+        >>> colvar = cvlib.AtomicFunction('angle(p1, p2, p3)', [0, 11, 21], "radians", False)
+        >>> [model.system.addForce(f) for f in [angle, colvar]]
+        [5, 6]
+        >>> integrator = mm.VerletIntegrator(0)
+        >>> platform = mm.Platform.getPlatformByName('Reference')
+        >>> context = mm.Context(model.system, integrator, platform)
+        >>> context.setPositions(model.positions)
+        >>> print(angle.evaluateInContext(context, 6))
+        2.318322 rad
+        >>> print(colvar.evaluateInContext(context, 6))
+        2.318322 rad
+    """
+
+    def __init__(
+        self,
+        function: str,
+        group: Iterable[int],
+        unit: UnitOrStr = mmunit.dimensionless,
+        pbc: bool = True,
+    ) -> None:
+        super().__init__(len(group), function)
+        self.addBond(group, [])
+        self.setUsesPeriodicBoundaryConditions(pbc)
+        cv_unit = str_to_unit(unit) if isinstance(unit, str) else unit
+        if in_md_units(1 * cv_unit) != 1:
+            raise ValueError(f"Unit {cv_unit} is not compatible with the MD unit system.")
+        self._registerCV(cv_unit, str(unit), function, group, pbc)

--- a/cvlib/centroid_function.py
+++ b/cvlib/centroid_function.py
@@ -10,9 +10,8 @@
 from typing import Iterable
 
 import openmm
-from openmm import unit as mmunit
 
-from .cvlib import AbstractCollectiveVariable, UnitOrStr, str_to_unit, in_md_units
+from .cvlib import AbstractCollectiveVariable, UnitOrStr, in_md_units, str_to_unit
 
 
 class CentroidFunction(openmm.CustomCentroidBondForce, AbstractCollectiveVariable):
@@ -48,21 +47,22 @@ class CentroidFunction(openmm.CustomCentroidBondForce, AbstractCollectiveVariabl
     ----------
         function
             The function to be evaluated. It must be a valid :OpenMM:`CustomCentroidBondForce`
-            expression.
+            expression
         groups
             The groups of atoms to be used in the function. Each group must be a list of atom
-            indices.
+            indices
         unit
             The unit of measurement of the collective variable. It must be compatible with the
             MD unit system (mass in `daltons`, distance in `nanometers`, time in `picoseconds`,
-            temperature in `kelvin`, energy in `kilojoules_per_mol`, angle in `radians`).
+            temperature in `kelvin`, energy in `kilojoules_per_mol`, angle in `radians`). If
+            the collective variables does not have a unit, use `dimensionless`
         pbc
-            Whether to use periodic boundary conditions.
+            Whether to use periodic boundary conditions
 
     Raises
     ------
         ValueError
-            If the collective variable is not compatible with the MD unit system.
+            If the collective variable is not compatible with the MD unit system
 
     Example
     -------
@@ -94,7 +94,7 @@ class CentroidFunction(openmm.CustomCentroidBondForce, AbstractCollectiveVariabl
         self,
         function: str,
         groups: Iterable[Iterable[int]],
-        unit: UnitOrStr = mmunit.dimensionless,
+        unit: UnitOrStr,
         pbc: bool = False,
         weighByMass: bool = False,
     ) -> None:
@@ -107,4 +107,4 @@ class CentroidFunction(openmm.CustomCentroidBondForce, AbstractCollectiveVariabl
         cv_unit = str_to_unit(unit) if isinstance(unit, str) else unit
         if in_md_units(1 * cv_unit) != 1:
             raise ValueError(f"Unit {cv_unit} is not compatible with the MD unit system.")
-        self._registerCV(cv_unit, str(unit), function, groups, pbc)
+        self._registerCV(cv_unit, function, groups, str(unit), pbc)

--- a/cvlib/centroid_function.py
+++ b/cvlib/centroid_function.py
@@ -1,0 +1,110 @@
+"""
+.. class:: CentroidFunction
+   :platform: Linux, MacOS, Windows
+   :synopsis: A generic function of the centroids of groups of atoms
+
+.. classauthor:: Charlles Abreu <craabreu@gmail.com>
+
+"""
+
+from typing import Iterable
+
+import openmm
+from openmm import unit as mmunit
+
+from .cvlib import AbstractCollectiveVariable, UnitOrStr, str_to_unit, in_md_units
+
+
+class CentroidFunction(openmm.CustomCentroidBondForce, AbstractCollectiveVariable):
+    """
+    A generic function of the centroids of `n` groups of atoms:
+
+    .. math::
+
+        f({\\bf r}) = F({\\bf R}_1, {\\bf R}_2, \\dots, {\\bf R}_n)
+
+    where :math:`F` is a user-defined function and :math:`{\\bf R}_i` is the centroid of the
+    :math:`i`-th group of atoms. The function :math:`F` is defined as a string and can be any valid
+    :OpenMM:`CustomCentroidBondForce` expression.
+
+    The centroid of a group of atoms is defined as:
+
+    .. math::
+
+        {\\bf R}_i({\\bf r}) = \\frac{1}{n_i} \\sum_{j=1}^{n_i} {\\bf r}_{j, i}
+
+    where :math:`n_i` is the number of atoms in group :math:`i` and :math:`{\\bf r}_{j, i}` is the
+    position of the :math:`j`-th atom in group :math:`i`. Optionally, the centroid can be weighted
+    by the mass of each atom in the group. In this case, it is defined as:
+
+    .. math::
+
+        {\\bf R}_i({\\bf r}) = \\frac{1}{M_i} \\sum_{j=1}^{n_i} m_{j, i} {\\bf r}_{j, i}
+
+    where :math:`M_i` is the total mass of group :math:`i` and :math:`m_{j, i}` is the mass of the
+    :math:`j`-th atom in group :math:`i`.
+
+    Parameters
+    ----------
+        function
+            The function to be evaluated. It must be a valid :OpenMM:`CustomCentroidBondForce`
+            expression.
+        groups
+            The groups of atoms to be used in the function. Each group must be a list of atom
+            indices.
+        unit
+            The unit of measurement of the collective variable. It must be compatible with the
+            MD unit system (mass in `daltons`, distance in `nanometers`, time in `picoseconds`,
+            temperature in `kelvin`, energy in `kilojoules_per_mol`, angle in `radians`).
+        pbc
+            Whether to use periodic boundary conditions.
+
+    Raises
+    ------
+        ValueError
+            If the collective variable is not compatible with the MD unit system.
+
+    Example
+    -------
+        >>> import cvlib
+        >>> import openmm as mm
+        >>> from openmmtools import testsystems
+        >>> model = testsystems.AlanineDipeptideVacuum()
+        >>> num_atoms = model.system.getNumParticles()
+        >>> atoms = list(range(num_atoms))
+        >>> rg = cvlib.RadiusOfGyration(atoms)
+        >>> definitions = [f'd{i+1} = distance(g{i+1}, g{num_atoms+1})' for i in atoms]
+        >>> sum_dist_sq = "+".join(f'd{i+1}^2' for i in atoms)
+        >>> function = ";".join([f"sqrt(({sum_dist_sq})/{num_atoms})"] + definitions)
+        >>> groups = [[i] for i in atoms] + [atoms]
+        >>> colvar = cvlib.CentroidFunction(function, groups, "nanometers")
+        >>> [model.system.addForce(f) for f in [rg, colvar]]
+        [5, 6]
+        >>> integrator = mm.VerletIntegrator(0)
+        >>> platform = mm.Platform.getPlatformByName('Reference')
+        >>> context = mm.Context(model.system, integrator, platform)
+        >>> context.setPositions(model.positions)
+        >>> print(rg.evaluateInContext(context, 6))
+        0.295143 nm
+        >>> print(colvar.evaluateInContext(context, 6))
+        0.295143 nm
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        function: str,
+        groups: Iterable[Iterable[int]],
+        unit: UnitOrStr = mmunit.dimensionless,
+        pbc: bool = False,
+        weighByMass: bool = False,
+    ) -> None:
+        num_groups = len(groups)
+        super().__init__(num_groups, function)
+        for group in groups:
+            self.addGroup(group, None if weighByMass else [1] * len(group))
+        self.addBond(list(range(num_groups)), [])
+        self.setUsesPeriodicBoundaryConditions(pbc)
+        cv_unit = str_to_unit(unit) if isinstance(unit, str) else unit
+        if in_md_units(1 * cv_unit) != 1:
+            raise ValueError(f"Unit {cv_unit} is not compatible with the MD unit system.")
+        self._registerCV(cv_unit, str(unit), function, groups, pbc)


### PR DESCRIPTION
## Description

Implemented two collective variables for the evaluation of user-defined functions:

* __AtomicFunction__: a function of the atomic coordinates of a provided group of atoms. The atoms are referred to in the user-defined expression by `p1`, `p2`, etc. Their coordinates are `x1`, `y1`, `z1`, `x2`, `y2`, `z2`, etc.
* __CentroidFunction__: a function of the centroids of provided groups of atoms. The groups are referred to in the user-defined expression by `g1`, `g2`, etc. Their coordinates are `x1`, `y1`, `z1`, `x2`, `y2`, `z2`, etc.